### PR TITLE
Submoduled DPR-JS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "public/dpr-js"]
+	path = public/dpr-js
+	url = https://github.com/frictionlessdata/dpr-js

--- a/routes/index.js
+++ b/routes/index.js
@@ -29,7 +29,7 @@ module.exports = function () {
     res.render('showcase.html', {
       title: req.params.owner + ' | ' + req.params.name,
       dataset: dpjson,
-      datapackageUrl: dpBitStoreUrl,
+      datapackageUrl: dpBitStoreUrl + '/datapackage.json',
       readmeShort: '',
 			// eslint-disable-next-line camelcase
       readme_long: readme

--- a/views/showcase.html
+++ b/views/showcase.html
@@ -204,11 +204,11 @@
 
       <!-- pass datapackageUrl to front-end -->
       <script type="text/javascript">
-        var DATA_PACKAGE_URL = "https://bits-staging.datapackaged.com/metadata/admin/demo-package/_v/latest";//"{{ datapackageUrl }}";
+        var DATA_PACKAGE_URL = "{{ datapackageUrl }}";
       </script>
     </div>
   </div>
-  <link rel="stylesheet" media="screen" href="{{ s3_cdn }}/static/dpr-js/dist/main.css">
-  <script type="text/javascript" src="{{ s3_cdn }}/static/dpr-js/dist/bundle.js"></script>
+  <link rel="stylesheet" media="screen" href="/static/dpr-js/dist/main.css">
+  <script type="text/javascript" src="/static/dpr-js/dist/bundle.js"></script>
 </div>
 {% endblock %}


### PR DESCRIPTION
Submoduled `dpr-js` library which is used for rendering graphs and previews:

* `.gitmodules` with submodule instructions
* refactored routes - concatenated `/datapackage.json` to `bitStoreUrl`
* fixed importing `bundle.js` and `main.css` into showcase page